### PR TITLE
[JOO-903]: Chore: Remove Session ID

### DIFF
--- a/.changeset/eight-kiwis-live.md
+++ b/.changeset/eight-kiwis-live.md
@@ -1,0 +1,6 @@
+---
+'@alore/auth-react-sdk': minor
+'@alore/auth-react-ui': minor
+---
+
+Removed session_id

--- a/packages/alore-auth-sdk/src/types.ts
+++ b/packages/alore-auth-sdk/src/types.ts
@@ -46,7 +46,6 @@ export interface AuthMachineContext {
   salt?: string;
   error?: string;
   active2fa?: TwoFactorAuth[];
-  sessionId?: string;
   registerUser?: {
     email: string;
     nickname: string;

--- a/packages/alore-auth-sdk/src/utils/AloreAuth.ts
+++ b/packages/alore-auth-sdk/src/utils/AloreAuth.ts
@@ -84,7 +84,6 @@ export class AloreAuth {
           },
           body: JSON.stringify({
             emailCode: secureCode,
-            sessionId: context.sessionId,
           }),
         },
       );
@@ -210,8 +209,8 @@ export class AloreAuth {
 
       if (response.ok) {
         const resJson = await response.json();
-        const { salt, sessionId } = resJson;
-        return { salt, sessionId };
+        const { salt } = resJson;
+        return { salt };
       }
 
       // Throw parsed error for machine to consume
@@ -295,19 +294,11 @@ export class AloreAuth {
         },
       );
 
-      const data = await response.json();
-
       if (!response.ok) {
-        if (response.status === 403) {
-          return { active2fa: data };
-        }
-        if (data?.error?.includes('2FA') || data?.error?.includes('device')) {
-          return { error: data?.error };
-        }
         await this.throwParsedResponseError(response);
-      } else {
-        return data;
       }
+
+      return {};
     },
     // Passkey registration flow
     startRegisterPasskey: async (
@@ -382,7 +373,6 @@ export class AloreAuth {
             userNickname: nickname || null,
             userDevice: device,
             passkeyRegistration,
-            sessionId: context.sessionId,
             rpOrigin: rpDomain,
           }),
         },
@@ -474,7 +464,6 @@ export class AloreAuth {
           },
           body: JSON.stringify({
             passkeyAuth,
-            sessionId: context.sessionId,
             rpOrigin: rpDomain,
           }),
         },
@@ -572,7 +561,6 @@ export class AloreAuth {
             passwordHash,
             device,
             credential,
-            sessionId: optionsData.sessionId,
           }),
         },
       );
@@ -609,7 +597,6 @@ export class AloreAuth {
             passwordHash,
             deviceSecret: device,
             emailCode: secureCode,
-            sessionId: context.sessionId,
           }),
         },
       );
@@ -644,7 +631,6 @@ export class AloreAuth {
             email: email || credentialEmail,
             passwordHash,
             emailCode: secureCode,
-            sessionId: context.sessionId,
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -707,7 +693,6 @@ export class AloreAuth {
           body: JSON.stringify({
             email,
             emailCode,
-            sessionId: context.sessionId,
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -776,7 +761,6 @@ export class AloreAuth {
             nickname: data.nickname,
             salt: data.salt,
           },
-          sessionId: data.sessionId,
         };
       }
 
@@ -814,7 +798,6 @@ export class AloreAuth {
           email,
           emailCode: otp,
           passwordHash,
-          sessionId: context.sessionId,
         }),
         headers: {
           'Content-Type': 'application/json',

--- a/packages/alore-auth-ui/src/machine/index.ts
+++ b/packages/alore-auth-ui/src/machine/index.ts
@@ -8,7 +8,6 @@ const initialContext: AuthMachineContext = {
   salt: undefined,
   error: undefined,
   active2fa: undefined,
-  sessionId: undefined,
   registerUser: undefined,
   socialProviderRegisterUser: undefined,
   googleOtpCode: undefined,
@@ -48,7 +47,6 @@ export const authMachine = createMachine(
         },
         exit: assign({
           error: () => undefined,
-          sessionId: () => undefined,
           credentialEmail: () => undefined,
         }),
       },
@@ -76,7 +74,6 @@ export const authMachine = createMachine(
                   registerUser: () => undefined,
                   socialProviderRegisterUser: () => undefined,
                   salt: () => undefined,
-                  sessionId: () => undefined,
                 }),
               },
 
@@ -85,7 +82,6 @@ export const authMachine = createMachine(
                   src: 'verifyEmailEligibility',
                   onDone: {
                     target: 'email2faCode',
-                    actions: 'setSessionId',
                   },
                   onError: {
                     target: 'emailInput',
@@ -225,7 +221,6 @@ export const authMachine = createMachine(
                         googleUser: () => undefined,
                         registerUser: () => undefined,
                         socialProviderRegisterUser: () => undefined,
-                        sessionId: () => undefined,
                         CCRPublicKey: () => undefined,
                         RCRPublicKey: () => undefined,
                       }),
@@ -471,7 +466,6 @@ export const authMachine = createMachine(
                     },
                     {
                       target: 'email2fa',
-                      actions: 'setSessionId',
                     },
                   ],
                   onError: {
@@ -536,7 +530,7 @@ export const authMachine = createMachine(
                       target: 'newDevice',
                       cond: 'isNewDevice',
                     },
-                    { target: 'successfulLogin', actions: 'setSessionUser' },
+                    { target: 'successfulLogin' },
                   ],
                   onError: {
                     target: 'software2fa',
@@ -576,7 +570,6 @@ export const authMachine = createMachine(
 
                   onDone: {
                     target: 'successfulLogin',
-                    actions: 'setSessionUser',
                   },
 
                   onError: {
@@ -641,7 +634,6 @@ export const authMachine = createMachine(
 
                   onDone: {
                     target: 'successfulLogin',
-                    actions: 'setSessionUser',
                   },
                 },
                 entry: assign({
@@ -654,7 +646,6 @@ export const authMachine = createMachine(
                   src: 'verifyLogin',
                   onDone: {
                     target: 'email2fa',
-                    actions: 'setSessionId',
                   },
                 },
                 entry: assign({
@@ -671,7 +662,7 @@ export const authMachine = createMachine(
                       target: 'newDevice',
                       cond: 'isNewDevice',
                     },
-                    { target: 'successfulLogin', actions: 'setSessionUser' },
+                    { target: 'successfulLogin' },
                   ],
 
                   onError: {
@@ -737,7 +728,6 @@ export const authMachine = createMachine(
                         googleOtpCode: (_, event) => event.data.googleOtpCode,
                         salt: (_, event) => event.data.salt,
                         googleUser: (_, event) => event.data.googleUser,
-                        sessionId: (_, event) => event.data.sessionId,
                       }),
                     },
                   ],
@@ -779,7 +769,6 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.login.signingCredentialRCR',
                     actions: assign({
                       RCRPublicKey: (_context, event) => event.data.requestChallengeResponse,
-                      sessionId: (_, event) => event.data.sessionId,
                     }),
                   },
                   onError: {
@@ -889,7 +878,6 @@ export const authMachine = createMachine(
             exit: assign({
               RCRPublicKey: () => undefined,
               CCRPublicKey: () => undefined,
-              sessionId: () => undefined,
             }),
           },
 
@@ -941,7 +929,6 @@ export const authMachine = createMachine(
                     target: 'emailValidation',
                     actions: assign({
                       salt: (_context, event) => event.data?.salt,
-                      sessionId: (_context, event) => event.data?.sessionId,
                     }),
                   },
                   onError: {
@@ -1080,7 +1067,6 @@ export const authMachine = createMachine(
                   src: 'sendConfirmationEmail',
                   onDone: {
                     target: 'emailValidation',
-                    actions: 'setSessionId',
                   },
                 },
                 entry: assign({
@@ -1107,7 +1093,6 @@ export const authMachine = createMachine(
                         googleOtpCode: (_, event) => event.data.googleOtpCode,
                         salt: (_, event) => event.data.salt,
                         googleUser: (_, event) => event.data.googleUser,
-                        sessionId: (_, event) => event.data.sessionId,
                       }),
                     },
                   ],
@@ -1139,7 +1124,6 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.register.localCCRSign',
                     actions: assign({
                       CCRPublicKey: (_context, event) => event.data.ccr,
-                      sessionId: (_, event) => event.data.sessionId,
                     }),
                   },
 
@@ -1207,7 +1191,6 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.register.waitingForRCR',
                     actions: assign({
                       RCRPublicKey: () => undefined,
-                      sessionId: () => undefined,
                     }),
                   },
                   onError: {
@@ -1243,7 +1226,6 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.register.localRCRSign',
                     actions: assign({
                       RCRPublicKey: (_context, event) => event.data.requestChallengeResponse,
-                      sessionId: (_, event) => event.data.sessionId,
                     }),
                   },
                   onError: {
@@ -1616,9 +1598,6 @@ export const authService = (services: {}, context: AuthMachineContext) => {
               ...ctx.sessionUser!,
               accessToken: event.newAccessToken,
             }),
-          }),
-          setSessionId: assign({
-            sessionId: (_, event) => event.data.sessionId,
           }),
           setSessionUser: assign({
             sessionUser: (_, event) => event.data,

--- a/packages/alore-auth-ui/src/machine/index.ts
+++ b/packages/alore-auth-ui/src/machine/index.ts
@@ -530,7 +530,7 @@ export const authMachine = createMachine(
                       target: 'newDevice',
                       cond: 'isNewDevice',
                     },
-                    { target: 'successfulLogin' },
+                    { target: 'successfulLogin', actions: 'setSessionUser' },
                   ],
                   onError: {
                     target: 'software2fa',
@@ -570,6 +570,7 @@ export const authMachine = createMachine(
 
                   onDone: {
                     target: 'successfulLogin',
+                    actions: 'setSessionUser',
                   },
 
                   onError: {
@@ -634,6 +635,7 @@ export const authMachine = createMachine(
 
                   onDone: {
                     target: 'successfulLogin',
+                    actions: 'setSessionUser',
                   },
                 },
                 entry: assign({
@@ -662,7 +664,10 @@ export const authMachine = createMachine(
                       target: 'newDevice',
                       cond: 'isNewDevice',
                     },
-                    { target: 'successfulLogin' },
+                    {
+                      target: 'successfulLogin',
+                      actions: 'setSessionUser',
+                    },
                   ],
 
                   onError: {

--- a/packages/alore-auth-ui/src/machine/types.ts
+++ b/packages/alore-auth-ui/src/machine/types.ts
@@ -30,7 +30,6 @@ export interface AuthMachineContext {
     data?: any;
   };
   active2fa?: TwoFactorAuth[];
-  sessionId?: string;
   registerUser?: {
     email: string;
     nickname: string;
@@ -270,7 +269,6 @@ type AuthReturn = {
   data: {
     error?: string;
     salt?: string;
-    sessionId?: string;
   };
 };
 


### PR DESCRIPTION
With the new Alore update with nats and actix_session, the manual handle of session id its not required anymore.
[Issue](https://linear.app/bealore/issue/JOO-903/bug-erro-no-cache-do-session-id-alore-auth)