### PR TITLE
Revert "Merge pull request #56 from 0xCarbon/chore/remove-session-id"

### DIFF
--- a/.changeset/eight-kiwis-live.md
+++ b/.changeset/eight-kiwis-live.md
@@ -1,6 +1,0 @@
----
-'@alore/auth-react-sdk': minor
-'@alore/auth-react-ui': minor
----
-
-Removed session_id

--- a/.changeset/eight-kiwis-live.md
+++ b/.changeset/eight-kiwis-live.md
@@ -1,0 +1,6 @@
+---
+'@alore/auth-react-sdk': minor
+'@alore/auth-react-ui': minor
+---
+
+Removed session_id

--- a/.changeset/late-rooms-occur.md
+++ b/.changeset/late-rooms-occur.md
@@ -1,0 +1,6 @@
+---
+'@alore/auth-react-sdk': minor
+'@alore/auth-react-ui': minor
+---
+
+Added sessionId again

--- a/packages/alore-auth-sdk/src/types.ts
+++ b/packages/alore-auth-sdk/src/types.ts
@@ -46,6 +46,7 @@ export interface AuthMachineContext {
   salt?: string;
   error?: string;
   active2fa?: TwoFactorAuth[];
+  sessionId?: string;
   registerUser?: {
     email: string;
     nickname: string;

--- a/packages/alore-auth-ui/src/machine/index.ts
+++ b/packages/alore-auth-ui/src/machine/index.ts
@@ -8,6 +8,7 @@ const initialContext: AuthMachineContext = {
   salt: undefined,
   error: undefined,
   active2fa: undefined,
+  sessionId: undefined,
   registerUser: undefined,
   socialProviderRegisterUser: undefined,
   googleOtpCode: undefined,
@@ -47,6 +48,7 @@ export const authMachine = createMachine(
         },
         exit: assign({
           error: () => undefined,
+          sessionId: () => undefined,
           credentialEmail: () => undefined,
         }),
       },
@@ -74,6 +76,7 @@ export const authMachine = createMachine(
                   registerUser: () => undefined,
                   socialProviderRegisterUser: () => undefined,
                   salt: () => undefined,
+                  sessionId: () => undefined,
                 }),
               },
 
@@ -82,6 +85,7 @@ export const authMachine = createMachine(
                   src: 'verifyEmailEligibility',
                   onDone: {
                     target: 'email2faCode',
+                    actions: 'setSessionId',
                   },
                   onError: {
                     target: 'emailInput',
@@ -221,6 +225,7 @@ export const authMachine = createMachine(
                         googleUser: () => undefined,
                         registerUser: () => undefined,
                         socialProviderRegisterUser: () => undefined,
+                        sessionId: () => undefined,
                         CCRPublicKey: () => undefined,
                         RCRPublicKey: () => undefined,
                       }),
@@ -466,6 +471,7 @@ export const authMachine = createMachine(
                     },
                     {
                       target: 'email2fa',
+                      actions: 'setSessionId',
                     },
                   ],
                   onError: {
@@ -648,6 +654,7 @@ export const authMachine = createMachine(
                   src: 'verifyLogin',
                   onDone: {
                     target: 'email2fa',
+                    actions: 'setSessionId',
                   },
                 },
                 entry: assign({
@@ -664,10 +671,7 @@ export const authMachine = createMachine(
                       target: 'newDevice',
                       cond: 'isNewDevice',
                     },
-                    {
-                      target: 'successfulLogin',
-                      actions: 'setSessionUser',
-                    },
+                    { target: 'successfulLogin', actions: 'setSessionUser' },
                   ],
 
                   onError: {
@@ -733,6 +737,7 @@ export const authMachine = createMachine(
                         googleOtpCode: (_, event) => event.data.googleOtpCode,
                         salt: (_, event) => event.data.salt,
                         googleUser: (_, event) => event.data.googleUser,
+                        sessionId: (_, event) => event.data.sessionId,
                       }),
                     },
                   ],
@@ -774,6 +779,7 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.login.signingCredentialRCR',
                     actions: assign({
                       RCRPublicKey: (_context, event) => event.data.requestChallengeResponse,
+                      sessionId: (_, event) => event.data.sessionId,
                     }),
                   },
                   onError: {
@@ -883,6 +889,7 @@ export const authMachine = createMachine(
             exit: assign({
               RCRPublicKey: () => undefined,
               CCRPublicKey: () => undefined,
+              sessionId: () => undefined,
             }),
           },
 
@@ -934,6 +941,7 @@ export const authMachine = createMachine(
                     target: 'emailValidation',
                     actions: assign({
                       salt: (_context, event) => event.data?.salt,
+                      sessionId: (_context, event) => event.data?.sessionId,
                     }),
                   },
                   onError: {
@@ -1072,6 +1080,7 @@ export const authMachine = createMachine(
                   src: 'sendConfirmationEmail',
                   onDone: {
                     target: 'emailValidation',
+                    actions: 'setSessionId',
                   },
                 },
                 entry: assign({
@@ -1098,6 +1107,7 @@ export const authMachine = createMachine(
                         googleOtpCode: (_, event) => event.data.googleOtpCode,
                         salt: (_, event) => event.data.salt,
                         googleUser: (_, event) => event.data.googleUser,
+                        sessionId: (_, event) => event.data.sessionId,
                       }),
                     },
                   ],
@@ -1129,6 +1139,7 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.register.localCCRSign',
                     actions: assign({
                       CCRPublicKey: (_context, event) => event.data.ccr,
+                      sessionId: (_, event) => event.data.sessionId,
                     }),
                   },
 
@@ -1196,6 +1207,7 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.register.waitingForRCR',
                     actions: assign({
                       RCRPublicKey: () => undefined,
+                      sessionId: () => undefined,
                     }),
                   },
                   onError: {
@@ -1231,6 +1243,7 @@ export const authMachine = createMachine(
                     target: '#authMachine.active.register.localRCRSign',
                     actions: assign({
                       RCRPublicKey: (_context, event) => event.data.requestChallengeResponse,
+                      sessionId: (_, event) => event.data.sessionId,
                     }),
                   },
                   onError: {
@@ -1603,6 +1616,9 @@ export const authService = (services: {}, context: AuthMachineContext) => {
               ...ctx.sessionUser!,
               accessToken: event.newAccessToken,
             }),
+          }),
+          setSessionId: assign({
+            sessionId: (_, event) => event.data.sessionId,
           }),
           setSessionUser: assign({
             sessionUser: (_, event) => event.data,

--- a/packages/alore-auth-ui/src/machine/types.ts
+++ b/packages/alore-auth-ui/src/machine/types.ts
@@ -30,6 +30,7 @@ export interface AuthMachineContext {
     data?: any;
   };
   active2fa?: TwoFactorAuth[];
+  sessionId?: string;
   registerUser?: {
     email: string;
     nickname: string;
@@ -269,6 +270,7 @@ type AuthReturn = {
   data: {
     error?: string;
     salt?: string;
+    sessionId?: string;
   };
 };
 


### PR DESCRIPTION
This reverts commit bdc40333a16af7b7f8230e9ba207f827a2e00aef, reversing changes made to 9c060e251d0a4d7915ac2eaf6e7777c8a107748c.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reintroduces `sessionId` across SDK and UI, threading it through context and API calls for registration, login, passkey, and 2FA, with minor verifyLogin error handling updates.
> 
> - **SDK (`packages/alore-auth-sdk`)**:
>   - Add `sessionId` to `AuthMachineContext` and thread it through requests: `registration-code-verification`, `account-registration-passkey-finish`, `login-passkey-finish`, `hw-2fa-finish-verification`, `device-ownership-verification`, `email-2fa-verification`, `eligible-email-code-verification`, `google-2fa-verification`.
>   - `sendConfirmationEmail` now returns `{ salt, sessionId }`; include `sessionId` in subsequent flows.
>   - `verifyLogin`: parse response JSON; on 403 return `{ active2fa }`, bubble specific 2FA/device errors via `{ error }`, otherwise return full data.
> - **UI (`packages/alore-auth-ui`)**:
>   - Add `sessionId` to `AuthMachineContext`; introduce `setSessionId` action; clear `sessionId` on relevant exits.
>   - Capture/propagate `sessionId` on transitions: email eligibility, login verification/resend, Google login, passkey start (login/register), registration email send/resend, and other passkey steps; reset after sending public credential.
> - **Changeset**: bump minor for `@alore/auth-react-sdk` and `@alore/auth-react-ui` with note "Added sessionId again".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d763a0df1a247aa97195a9126ca927c0e1505397. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->