### PR TITLE
fix(auth-ui): prevent useEffect race resetting forgot-password state

### DIFF
--- a/packages/alore-auth-ui/src/components/Auth.tsx
+++ b/packages/alore-auth-ui/src/components/Auth.tsx
@@ -156,7 +156,14 @@ const Auth = ({
   }, []);
 
   useEffect(() => {
-    // Don't reset if we're in the middle of a password reset flow
+    // Don't reset if we're in the middle of a password reset flow.
+    // Check URL params directly to avoid stale-closure reads of forgotPasswordSession.
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('salt') && params.get('token')) {
+        return;
+      }
+    }
     if (!forgotPasswordSession) {
       sendAuth(['CLEAR_ERROR', 'RESET', 'INITIALIZE']);
     }


### PR DESCRIPTION
## Summary

- Fixes race condition in `Auth.tsx` where the `[authProviderConfigs]` useEffect would reset XState forgot-password state
- The effect's closure captured a stale `forgotPasswordSession === undefined`, causing it to call `RESET` even during an active password-reset flow
- Added URL param guard (`salt` + `token`) that reads directly from `window.location.search` — immune to stale closures

## Root cause

When a user lands on a password-reset link (`?salt=...&token=...`):
1. Effect 1 (`[]`) fires, sends `INITIALIZE` → `FORGOT_PASSWORD` → `RESET_PASSWORD`
2. `authProviderConfigs` updates (from INITIALIZE), triggering Effect 2
3. Effect 2 reads `forgotPasswordSession` from its closure — still `undefined` (assigned async by XState)
4. Effect 2 sends `RESET`, wiping the forgot-password state

The fix checks URL params directly in Effect 2 before deciding to reset.

## Test plan

- [ ] Password reset flow: visit `?salt=...&token=...`, type new password, submit → "Nova senha criada" appears
- [ ] Normal login flow: no regression — Effect 2 still resets on config changes
- [ ] Validated via joori E2E `change-password.spec.ts` with local tarball override