### PR TITLE
fix(auth-ui): keep authenticated session when authProviderConfigs change (JOO-1964)

### DIFF
--- a/.changeset/keep-session-on-config-change.md
+++ b/.changeset/keep-session-on-config-change.md
@@ -1,0 +1,12 @@
+---
+'@alore/auth-react-ui': patch
+---
+
+Keep the authenticated session when `authProviderConfigs` change. A new frontend
+deploy bakes different env-derived values (URLs, flags) into the config object;
+the persisted-state guard treated that as a reason to discard the entire
+persisted auth snapshot — including the access/refresh tokens — logging every
+user out on every deploy. Now a config change only resets login-flow UI state:
+when the persisted snapshot is an authenticated session
+(`active.login.successfulLogin` with a `sessionUser`), the session is kept and
+the incoming configs are adopted.

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -219,6 +219,7 @@ ipfs
 ipstack
 Isahc
 JEF
+JOO
 jsonwebtoken
 jwt
 keccak

--- a/packages/alore-auth-ui/src/machine/index.ts
+++ b/packages/alore-auth-ui/src/machine/index.ts
@@ -1632,7 +1632,28 @@ export const authService = (services: {}, context: AuthMachineContext) => {
   const configsDiffer =
     JSON.stringify(persistedConfig || {}) !== JSON.stringify(incomingConfig || {});
 
-  const startArg = configsDiffer ? undefined : resolvedState;
+  let startArg = configsDiffer ? undefined : resolvedState;
+
+  // A config change usually means a new frontend deploy baked different env-derived
+  // values (URLs, flags). That invalidates persisted login-flow UI state, but it must
+  // not cost an authenticated user their session: keep the logged-in snapshot and
+  // adopt the incoming configs instead of discarding the tokens (JOO-1964).
+  if (
+    configsDiffer &&
+    resolvedState?.context?.sessionUser &&
+    resolvedState.matches('active.login.successfulLogin')
+  ) {
+    const persistedSnapshot = JSON.parse(JSON.stringify(resolvedState));
+    const patchedState = State.create({
+      ...persistedSnapshot,
+      context: {
+        ...persistedSnapshot.context,
+        authProviderConfigs: incomingConfig,
+      },
+    });
+    // @ts-ignore
+    startArg = authMachine.resolveState(patchedState);
+  }
 
   return interpret(
     authMachine.withConfig(

--- a/packages/alore-auth-ui/src/machine/index.ts
+++ b/packages/alore-auth-ui/src/machine/index.ts
@@ -1638,10 +1638,14 @@ export const authService = (services: {}, context: AuthMachineContext) => {
   // values (URLs, flags). That invalidates persisted login-flow UI state, but it must
   // not cost an authenticated user their session: keep the logged-in snapshot and
   // adopt the incoming configs instead of discarding the tokens (JOO-1964).
+  // Exception: passkeys are cryptographically bound to rpDomain — if it changed,
+  // a kept session could no longer complete any WebAuthn flow, so fall back to
+  // the old start-fresh behavior.
   if (
     configsDiffer &&
     resolvedState?.context?.sessionUser &&
-    resolvedState.matches('active.login.successfulLogin')
+    resolvedState.matches('active.login.successfulLogin') &&
+    persistedConfig?.rpDomain === incomingConfig?.rpDomain
   ) {
     const persistedSnapshot = JSON.parse(JSON.stringify(resolvedState));
     const patchedState = State.create({
@@ -1649,10 +1653,17 @@ export const authService = (services: {}, context: AuthMachineContext) => {
       context: {
         ...persistedSnapshot.context,
         authProviderConfigs: incomingConfig,
+        // Login-flow leftovers; stale values must not survive into the kept session.
+        salt: undefined,
+        sessionId: undefined,
       },
     });
     // @ts-ignore
     startArg = authMachine.resolveState(patchedState);
+    // Persist right away: .start() does not fire a persisting transition
+    // (state.changed is undefined on boot), and without this every boot would
+    // re-run the patch until the next persisted transition.
+    localStorage.setItem('authState', JSON.stringify(startArg));
   }
 
   return interpret(


### PR DESCRIPTION
## Contexto

Todo deploy do front da Joori desloga os usuários ([JOO-1964](https://linear.app/bealore/issue/JOO-1964), confirmado na daily de 2026-06-11): o build bake-a valores derivados de env (`NEXT_PUBLIC_*` em URLs/flags) dentro de `authProviderConfigs`, e o guard `configsDiffer` do `authService` descartava o snapshot persistido INTEIRO do localStorage — **tokens de acesso/refresh incluídos** — sempre que a config persistida diferisse da recebida.

## Fix

Mudança de config passa a resetar só estado de fluxo de login: quando o snapshot persistido é uma sessão autenticada (`active.login.successfulLogin` com `sessionUser`), o snapshot é mantido e a config nova é adotada via `State.create` + `resolveState` (mesmo roundtrip da hidratação existente).

Hardenings da review adversarial:
- **`rpDomain` mudou ⇒ não preserva** — passkeys são presas criptograficamente ao domínio; sessão mantida não completaria nenhum fluxo WebAuthn.
- `salt`/`sessionId` stale limpos do contexto patchado.
- Snapshot patchado persistido imediatamente (boot não dispara transição persistente; sem isso o patch re-rodaria a cada cold boot).

## Validação

`pnpm --filter @alore/auth-react-ui build` (tsc esm+cjs) e eslint limpos. Changeset patch incluído.

## Follow-up (joori)

Após publish do `@alore/auth-react-ui`, bump na joori fecha o ciclo do JOO-1964.