### PR TITLE
ci: publish via npm Trusted Publishing (OIDC) + manual dispatch lane

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,14 +4,21 @@ on:
   pull_request:
     types:
       - closed
+  # Manual re-run lane: `changeset publish` is idempotent — it publishes only
+  # versions missing from the registry, so dispatching on main after a failed
+  # automatic publish picks up exactly the unpublished tags.
+  workflow_dispatch:
 
 jobs:
   publish:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'changeset-release/')
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.head_ref, 'changeset-release/'))
     name: Publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # npm Trusted Publishing (OIDC): the registry trusts this workflow
+      # directly — no NPM_TOKEN secret involved.
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -20,7 +27,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted Publishing requires npm >= 11.5; Node 20 ships npm 10.x.
+      # Also: no registry-url on setup-node and no NODE_AUTH_TOKEN below —
+      # a configured token would take precedence over OIDC.
+      - name: Update npm (OIDC needs >= 11.5)
+        run: npm install -g npm@latest
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -36,5 +48,3 @@ jobs:
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes #78. `NPM_TOKEN` lost publish rights on npmjs (`404 PUT` on every publish — blocked `@alore/auth-react-ui@1.2.0-alpha.22`, the JOO-1964 fix).

Switches the publish job to **npm Trusted Publishing (OIDC)** — trusted publisher já cadastrado no npmjs para `@alore/auth-react-ui` (GitHub Actions / 0xCarbon/alore-js / publish.yml, environment vazio). Mudanças:
- `id-token: write` no job.
- `npm install -g npm@latest` (OIDC exige npm ≥ 11.5; Node 20 traz 10.x).
- Removidos `registry-url`/`NODE_AUTH_TOKEN`/`NPM_TOKEN` — token configurado teria precedência sobre OIDC.
- `workflow_dispatch`: `changeset publish` é idempotente (publica só o que falta no registry) — primeira execução manual na main destrava o alpha.22.

**Nota**: trusted publisher é por pacote — `@alore/auth-react-sdk` e `@alore/crypto-sdk` precisam do MESMO cadastro (mesmos valores) antes dos próximos releases deles.