### PR TITLE
ci(publish): pin npm@11 (npm@12 needs node 22)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,8 @@ jobs:
       # Trusted Publishing requires npm >= 11.5; Node 20 ships npm 10.x.
       # Also: no registry-url on setup-node and no NODE_AUTH_TOKEN below —
       # a configured token would take precedence over OIDC.
-      - name: Update npm (OIDC needs >= 11.5)
-        run: npm install -g npm@latest
+      - name: Update npm (OIDC needs >= 11.5, node-20 compatible)
+        run: npm install -g npm@11
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
First OIDC publish run (after #81) failed: `npm install -g npm@latest` resolves to npm@12 which requires node >=22; the job runs node 20.20.2. npm@11 satisfies the Trusted Publishing >=11.5 floor and is node-20 compatible. Publish is idempotent + has workflow_dispatch, so after this lands I will dispatch the publish lane to release 1.2.0-alpha.23 / 1.1.0-alpha.13.